### PR TITLE
Add an intermediary docker image with all cargo dependencies to speed up subsequent builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY ./target/release/rust-aqi-query .
 
 FROM debian:buster-slim
 EXPOSE 3030
-RUN apt-get update && apt-get install -y libssl1.1
+RUN apt-get update && apt-get install -y libssl1.1 ca-certificates
 RUN rm -r -f /var/lib/apt/lists/*
 COPY --from=builder /usr/src/rust-aqi-query/rust-aqi-query /usr/local/bin/rust-aqi-query
 #COPY --from=builder /usr/local/cargo/bin/rust-aqi-query /usr/local/bin/rust-aqi-query

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ COPY ./target/release/rust-aqi-query .
 #RUN cargo install --path .
 
 FROM debian:buster-slim
-RUN apt-get update && apt-get install -y libssl1.1 
+EXPOSE 3030
+RUN apt-get update && apt-get install -y libssl1.1
 RUN rm -r -f /var/lib/apt/lists/*
 COPY --from=builder /usr/src/rust-aqi-query/rust-aqi-query /usr/local/bin/rust-aqi-query
 #COPY --from=builder /usr/local/cargo/bin/rust-aqi-query /usr/local/bin/rust-aqi-query

--- a/run-rust-aqi-docker.sh
+++ b/run-rust-aqi-docker.sh
@@ -2,7 +2,6 @@
 # Configure .env file with your API Key and Zipcode
 docker run \
     --env-file .env \
-    --network="host" \
+    -p 3030:3030 \
     --rm \
-    rust-aqi-query:v1 
-
+    rust-aqi-query:v1

--- a/src/prom_support.rs
+++ b/src/prom_support.rs
@@ -106,5 +106,5 @@ pub async fn enable_prom() {
 
     let routes = metrics_route;
 
-    warp::serve(routes).run(([127, 0, 0, 1], 3030)).await;
+    warp::serve(routes).run(([0, 0, 0, 0], 3030)).await;
 }


### PR DESCRIPTION
This should fix the long build times for the docker image.  Also, some other networking tweaks to get it to run on mac/windows.  Guessing you were running this on linux.